### PR TITLE
fix: replace node-fetch with axios

### DIFF
--- a/packages/language-server/src/ui5-model.ts
+++ b/packages/language-server/src/ui5-model.ts
@@ -99,7 +99,7 @@ export async function getSemanticModelWithFetcher(
   });
 }
 
-async function getAxiosClient(): Promise<AxiosInstance> {
+export async function getAxiosClient(): Promise<AxiosInstance> {
   const version = DEFAULT_UI5_VERSION;
 
   const proxy = await getProxySettings();


### PR DESCRIPTION
use axios instead of note-fetch to better support proxy
impemen https over http proxy support and fetch proxy settings from NPM
"re #285"